### PR TITLE
docs: add badge for pkg size

### DIFF
--- a/.github/workflows/package_size.yml
+++ b/.github/workflows/package_size.yml
@@ -2,6 +2,10 @@ name: Package Size Report
 
 on: pull_request
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   pkg-size-report:
     name: Package Size Report
@@ -10,13 +14,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: Williams-RE/WRE-Server
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Debug Repository Access
+        run: |
+          git remote -v
+          git status
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 20
 
+      - name: Install dependencies
+        run: npm install
+
       - name: Package size report
-        uses: pkg-size/action@v1
+        uses: pkg-size/action@v1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package_size.yml
+++ b/.github/workflows/package_size.yml
@@ -12,24 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      
+      - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          repository: Williams-RE/WRE-Server
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Debug Repository Access
-        run: |
-          git remote -v
-          git status
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: npm install
 
       - name: Package size report
         uses: pkg-size/action@v1.1.1

--- a/.github/workflows/package_size.yml
+++ b/.github/workflows/package_size.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <img src="https://img.shields.io/github/issues-raw/Williams-RE/WRE-website?color=yellow"/>
   <img alt="license" src="https://img.shields.io/github/license/Williams-RE/WRE-website?color=%2357d3af">
   <img alt="last commit" src="https://img.shields.io/github/last-commit/Williams-RE/WRE-website?color=%2357d3af">
+  <img src= "https://github.com/Williams-RE/WRE-website/actions/workflows/package_size.yml/badge.svg"/>
 </p>
 
 To get started, cd into the project and run this:


### PR DESCRIPTION
## Description

<!-- Put the PR description here -->

## Related NOTION/Linear/JIRA tickets

<!-- MOT - [ticket ID here] - title of the ticket -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (This type of PR improves the codebase without adding new features or fixing bugs)
- [ ] Documentation (This change requires a documentation update)

## Testing

<!-- Tested locally, works fine! -->

## Screenshots/Screen Recordings :

## Notes

<!-- More details? Add here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new badge in the README for tracking the package size, providing immediate feedback on the project's status.
- **Enhancements**
	- Improved the GitHub Actions workflow for package size reporting with new permissions and debugging capabilities.
	- Updated the action for package size reporting to the latest version, ensuring better functionality and reliability.
	- Streamlined the workflow for checking out the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->